### PR TITLE
Fix Images not scaling properly (Issue #4) and fix some missing types in ts files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -970,13 +970,14 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       },
       "engines": {
@@ -1054,6 +1055,25 @@
         "@esbuild/win32-ia32": "0.19.11",
         "@esbuild/win32-x64": "0.19.11"
       }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1871,9 +1891,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -2856,12 +2876,13 @@
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
     },
     "es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "requires": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       }
     },
@@ -2928,6 +2949,24 @@
         "@esbuild/win32-arm64": "0.19.11",
         "@esbuild/win32-ia32": "0.19.11",
         "@esbuild/win32-x64": "0.19.11"
+      }
+    },
+    "esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+          "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+        }
       }
     },
     "estree-walker": {
@@ -3489,9 +3528,9 @@
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "typescript": "^5.3.3",
         "vite": "^4.5.1",
         "vite-plugin-top-level-await": "^1.4.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -756,6 +759,15 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "devOptional": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
@@ -1878,6 +1890,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "devOptional": true
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -2718,6 +2736,15 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
+    "@types/node": {
+      "version": "20.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.2.tgz",
+      "integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+      "devOptional": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "@types/pug": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
@@ -3521,6 +3548,12 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "devOptional": true
     },
     "uuid": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,17 @@
   "dependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.5.3",
     "@tsconfig/svelte": "^5.0.2",
+    "gifshot": "^0.4.5",
     "svelte": "^4.2.8",
     "svelte-check": "^3.6.3",
+    "svelte-i18n": "^4.0.0",
     "svelte-preprocess": "^5.1.3",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",
     "vite": "^4.5.1",
-    "gifshot": "^0.4.5",
-    "svelte-i18n": "^4.0.0",
     "vite-plugin-top-level-await": "^1.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.2"
   }
 }

--- a/src/lib/constants/flagColours.ts
+++ b/src/lib/constants/flagColours.ts
@@ -1,4 +1,9 @@
-export const flagColours = {
+export interface FlagColours {
+  [key: string]: string[]
+}
+
+
+export const flagColours: FlagColours = {
   "German Pride": [
     "#000000",
     "#49000b",

--- a/src/lib/drawFlags/drawChileanFlag.ts
+++ b/src/lib/drawFlags/drawChileanFlag.ts
@@ -1,12 +1,12 @@
-export function drawChileanFlag(canvas, ctx) {
-  var height = canvas.height;
-  var width = height * 1.9;
+export function drawChileanFlag(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
+  var height: number = canvas.height;
+  var width: number = height * 1.9;
 
-  const upperLeft = ["#14388c", "#0d3d91", "#173e99"];
+  const upperLeft: string[] = ["#14388c", "#0d3d91", "#173e99"];
 
-  const upperRight = ["#e2e3e5", "#e8e9ed", "#ffffff"];
+  const upperRight: string[] = ["#e2e3e5", "#e8e9ed", "#ffffff"];
 
-  var baseColors = ["#c80f2e", "#e30011", "#e30011"];
+  var baseColors: string[] = ["#c80f2e", "#e30011", "#e30011"];
 
   //draw upper left
   for (var i = 0; i < 3; i++) {

--- a/src/lib/drawFlags/drawCzechFlag.ts
+++ b/src/lib/drawFlags/drawCzechFlag.ts
@@ -1,7 +1,16 @@
-export function drawCzechFlag(canvas, ctx) {
-  var height = canvas.height;
-  var width = height * 1.9;
+export interface Canvas {
+  height: number;
+  width: number;
+}
 
+export interface Context {
+  fillStyle: string;
+  fillRect(x: number, y: number, width: number, height: number): void;
+}
+
+export function drawCzechFlag(canvas: Canvas, ctx: Context) {
+  var height: number = canvas.height;
+  var width: number = height * 1.9;
 
   // draw white
   ctx.fillStyle = "#ffffff";
@@ -10,6 +19,4 @@ export function drawCzechFlag(canvas, ctx) {
   // draw red
 
   // draw blue triangle
-
-
 }

--- a/src/lib/drawFlags/drawGreeceFlag.ts
+++ b/src/lib/drawFlags/drawGreeceFlag.ts
@@ -1,8 +1,8 @@
-export function drawGreeceFlag(canvas, ctx) {
-  var height = canvas.height;
-  var width = height * 1.9;
+export function drawGreeceFlag(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
+  var height: number = canvas.height;
+  var width: number = height * 1.9;
 
-  const baseColors = [
+  const baseColors: string[] = [
     "#148dd7",
     "#1ec6eb",
     "#2de2f5",
@@ -12,22 +12,21 @@ export function drawGreeceFlag(canvas, ctx) {
     "#ccfdfe",
   ];
 
-  var secBaseColors = ["#00c9fe", "#00dffe", "#ffffff", "#00f2fe"];
+  var secBaseColors: string[] = ["#00c9fe", "#00dffe", "#ffffff", "#00f2fe"];
 
   baseColors.reverse();
   secBaseColors.reverse();
 
   // base stripes
-  for (var i = 0; i < 7; i++) {
+  for (var i: number = 0; i < 7; i++) {
     ctx.fillStyle = baseColors[i];
     ctx.fillRect(0, i * (height / 7), width, height / 7);
   }
 
-  for (var i = 0; i < 4; i++) {
+  for (var i: number = 0; i < 4; i++) {
     ctx.fillStyle = secBaseColors[i];
     ctx.fillRect(0, i * (height / 7), width * 0.35, height / 7);
   }
-
 
   ctx.fillStyle = "#ffffff";
   ctx.fillRect(width / 7, 0, width / 14, (height / 7) * 4);

--- a/src/lib/drawFlags/drawUnionJack.ts
+++ b/src/lib/drawFlags/drawUnionJack.ts
@@ -1,8 +1,20 @@
-export function drawUnionjack(canvas, ctx){
+interface Canvas {
+    width: number;
+    height: number;
+}
 
+interface Context {
+    fillStyle: string;
+    strokeStyle: string;
+    lineWidth: number;
+    beginPath(): void;
+    moveTo(x: number, y: number): void;
+    lineTo(x: number, y: number): void;
+    stroke(): void;
+    fillRect(x: number, y: number, width: number, height: number): void;
+}
 
-
-
+export function drawUnionjack(canvas: Canvas, ctx: Context): void {
     ctx.fillStyle = "#00247d";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
@@ -23,29 +35,29 @@ export function drawUnionjack(canvas, ctx){
     ctx.strokeStyle = "#cf142b";
     ctx.lineWidth = canvas.width * 0.0333;
     ctx.beginPath();
-    ctx.moveTo(-canvas.width*0.05, -canvas.height*0.02);
-    ctx.lineTo(canvas.width/2, canvas.height*0.54);
+    ctx.moveTo(-canvas.width * 0.05, -canvas.height * 0.02);
+    ctx.lineTo(canvas.width / 2, canvas.height * 0.54);
     ctx.stroke();
 
     ctx.strokeStyle = "#cf142b";
     ctx.lineWidth = canvas.width * 0.0333;
     ctx.beginPath();
-    ctx.moveTo(0, canvas.height*1.04);
-    ctx.lineTo(canvas.width/2, canvas.height*0.54);
+    ctx.moveTo(0, canvas.height * 1.04);
+    ctx.lineTo(canvas.width / 2, canvas.height * 0.54);
     ctx.stroke();
 
     ctx.strokeStyle = "#cf142b";
     ctx.lineWidth = canvas.width * 0.0333;
     ctx.beginPath();
-    ctx.moveTo(canvas.width * 1.05555555, -canvas.height*0.1);
-    ctx.lineTo(canvas.width / 2, canvas.height*0.46);
+    ctx.moveTo(canvas.width * 1.05555555, -canvas.height * 0.1);
+    ctx.lineTo(canvas.width / 2, canvas.height * 0.46);
     ctx.stroke();
 
     ctx.strokeStyle = "#cf142b";
     ctx.lineWidth = canvas.width * 0.0333;
     ctx.beginPath();
-    ctx.moveTo(canvas.width * 1.05555555, canvas.height*1.02);
-    ctx.lineTo(canvas.width / 2, canvas.height*0.46);
+    ctx.moveTo(canvas.width * 1.05555555, canvas.height * 1.02);
+    ctx.lineTo(canvas.width / 2, canvas.height * 0.46);
     ctx.stroke();
 
     ctx.strokeStyle = "#fff";
@@ -58,8 +70,8 @@ export function drawUnionjack(canvas, ctx){
     ctx.strokeStyle = "#fff";
     ctx.lineWidth = canvas.width * 0.16;
     ctx.beginPath();
-    ctx.moveTo(canvas.width, canvas.height*0.5);
-    ctx.lineTo(0, canvas.height*0.5);
+    ctx.moveTo(canvas.width, canvas.height * 0.5);
+    ctx.lineTo(0, canvas.height * 0.5);
     ctx.stroke();
 
     ctx.strokeStyle = "#cf142b";
@@ -72,8 +84,7 @@ export function drawUnionjack(canvas, ctx){
     ctx.strokeStyle = "#cf142b";
     ctx.lineWidth = canvas.width * 0.11;
     ctx.beginPath();
-    ctx.moveTo(canvas.width, canvas.height*0.5);
-    ctx.lineTo(0, canvas.height*0.5);
+    ctx.moveTo(canvas.width, canvas.height * 0.5);
+    ctx.lineTo(0, canvas.height * 0.5);
     ctx.stroke();
-
 }

--- a/src/lib/drawFlags/drawUsaFlag.ts
+++ b/src/lib/drawFlags/drawUsaFlag.ts
@@ -1,68 +1,62 @@
-export function drawUSAFlag(canvas, ctx) {
-        // console.log('america');
-        var height = canvas.height;
-        var width = height * 1.9;
-        var xStarSeparation = height * 0.063;
-        var yStarSeparation = height * 0.054;
-    
-        //create white background
-    
-        ctx.fillStyle = "#ffffff";
-        ctx.fillRect(0, 0, width, height);
-    
-        //create red stripes
-    
-        for (var i = 0; i < 13; i += 2) {
-          ctx.fillStyle = "#e0162b";
-          ctx.fillRect(0, i * (height / 13), width, height / 13);
-        }
-    
-        //create blue box
-    
-        ctx.fillStyle = "#0052a5";
-        ctx.fillRect(0, 0, 0.76 * height, (7 / 13) * height);
-    
-        //fill stars and add to flag
-    
-        var outerRadius = (0.0616 * height) / 2;
-        var innerRadius =
-          (outerRadius * Math.sin(Math.PI / 10)) / Math.sin((7 * Math.PI) / 10);
-    
-        ctx.fillStyle = "#ffffff";
-        for (var row = 1; row <= 9; ++row) {
-          for (var col = 1; col <= 11; ++col) {
-            if ((row + col) % 2 == 0) {
-              drawStar(
-                canvas,
-                xStarSeparation * col,
-                yStarSeparation * row,
-                5,
-                outerRadius,
-                innerRadius
-              );
-              ctx.fill();
-            }
-          }
-        }
-    
-        //function used to build stars
-    
-        function drawStar(
-          context,
-          xCenter,
-          yCenter,
-          nPoints,
+export function drawUSAFlag(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D): void {
+  var height: number = canvas.height;
+  var width: number = height * 1.9;
+  var xStarSeparation: number = height * 0.063;
+  var yStarSeparation: number = height * 0.054;
+
+  //create white background
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(0, 0, width, height);
+
+  //create red stripes
+  for (var i: number = 0; i < 13; i += 2) {
+    ctx.fillStyle = "#e0162b";
+    ctx.fillRect(0, i * (height / 13), width, height / 13);
+  }
+
+  //create blue box
+  ctx.fillStyle = "#0052a5";
+  ctx.fillRect(0, 0, 0.76 * height, (7 / 13) * height);
+
+  //fill stars and add to flag
+  var outerRadius: number = (0.0616 * height) / 2;
+  var innerRadius: number =
+    (outerRadius * Math.sin(Math.PI / 10)) / Math.sin((7 * Math.PI) / 10);
+
+  ctx.fillStyle = "#ffffff";
+  for (var row: number = 1; row <= 9; ++row) {
+    for (var col: number = 1; col <= 11; ++col) {
+      if ((row + col) % 2 == 0) {
+        drawStar(
+          canvas,
+          xStarSeparation * col,
+          yStarSeparation * row,
+          5,
           outerRadius,
           innerRadius
-        ) {
-          ctx.beginPath();
-          for (var ixVertex = 0; ixVertex <= 2 * nPoints; ++ixVertex) {
-            var angle = (ixVertex * Math.PI) / nPoints - Math.PI / 2;
-            var radius = ixVertex % 2 == 0 ? outerRadius : innerRadius;
-            ctx.lineTo(
-              xCenter + radius * Math.cos(angle),
-              yCenter + radius * Math.sin(angle)
-            );
-          }
-        }
+        );
+        ctx.fill();
+      }
+    }
+  }
+
+  //function used to build stars
+  function drawStar(
+    context: HTMLCanvasElement,
+    xCenter: number,
+    yCenter: number,
+    nPoints: number,
+    outerRadius: number,
+    innerRadius: number
+  ): void {
+    ctx.beginPath();
+    for (var ixVertex: number = 0; ixVertex <= 2 * nPoints; ++ixVertex) {
+      var angle: number = (ixVertex * Math.PI) / nPoints - Math.PI / 2;
+      var radius: number = ixVertex % 2 == 0 ? outerRadius : innerRadius;
+      ctx.lineTo(
+        xCenter + radius * Math.cos(angle),
+        yCenter + radius * Math.sin(angle)
+      );
+    }
+  }
 }

--- a/src/lib/helpers/generateFlag.ts
+++ b/src/lib/helpers/generateFlag.ts
@@ -9,33 +9,39 @@ import { getPng } from "./PngHelper";
 /// Default ratio = 7:4
 export function generateFlag(
   colors: string[],
-  size: Size = new Size(105, 60)
+  size: Size = new Size(105, 60),
+  originalAspectRatio: number = 7 / 4 // default aspect ratio
 ): string {
   const canvas = document.createElement("canvas");
-  const ctx = canvas.getContext("2d");
+  const ctx = canvas.getContext("2d")!;
+
+  // Calculate new height based on original aspect ratio
+  const newHeight = size.width / originalAspectRatio;
 
   canvas.width = size.width;
-  canvas.height = size.height;
+  canvas.height = newHeight;
 
   if (colors[0] == "-") {
     for (let i = 1; i < colors.length; i++) {
       ctx.fillStyle = colors[i];
+      const rectWidth = size.width / (colors.length - 1);
       ctx.fillRect(
-        ((i - 1) * size.width) / (colors.length - 1),
+        ((i - 1) * rectWidth),
         0,
-        size.width / (colors.length - 1),
-        size.height
+        rectWidth,
+        newHeight
       );
     }
     return canvas.toDataURL();
   } else if (colors[0].startsWith("#")) {
     for (let i = 0; i < colors.length; i++) {
       ctx.fillStyle = colors[i];
+      const rectHeight = newHeight / colors.length;
       ctx.fillRect(
         0,
-        (i * size.height) / colors.length,
+        (i * rectHeight),
         size.width,
-        size.height / colors.length
+        rectHeight
       );
     }
     return canvas.toDataURL();


### PR DESCRIPTION
Gifshot is not compatible with ts, but I did not want to rewrite the gif generation process. 

The stretching issue is likely due to how the rectangles are drawn on the canvas. In the current implementation, the width and height of each rectangle are determined by dividing the total width and height of the canvas by the number of colors. This can lead to stretching if the aspect ratio of the individual rectangles doesn't match the aspect ratio of the original image.